### PR TITLE
Fixing install error on Windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ module_dir = this_dir / "espeak_phonemizer"
 long_description: str = ""
 readme_path = this_dir / "README.md"
 if readme_path.is_file():
-    long_description = readme_path.read_text()
+    long_description = readme_path.read_text(encoding="utf8")
 
 version_path = module_dir / "VERSION"
 with open(version_path, "r") as version_file:


### PR DESCRIPTION
When installing espeak_phonemizer on Windows, getting the error:
UnicodeDecodeError: 'charmap' codec can't decode byte 0x90 in position 707: character maps....

The issue is that README.md is UTF8 file but it is being read by the setup.py without specifying the encodings.

The issue was reported as issue # 111 on https://github.com/rhasspy/piper (https://github.com/rhasspy/piper/issues/111)