### PR TITLE
Update __init__.py

### DIFF
--- a/espeak_phonemizer/__init__.py
+++ b/espeak_phonemizer/__init__.py
@@ -220,7 +220,11 @@ class Phonemizer:
             # Already initialized
             return
 
-        library_names = ["libespeak-ng.so", "libespeak-ng.so.1", "libespeak-ng.dylib"]
+        library_names = ["libespeak-ng.so", 
+                         "libespeak-ng.so.1", 
+                         "libespeak-ng.dylib",
+                         "/opt/local/lib/libespeak-ng.dylib" # required for Mac OS X when installed `espeak-ng` with MacPorts; As of macOS 10.11 (El Capitan), the DYLD_LIBRARY_PATH environment variable appears to be ignored
+                        ]
 
         for lib_name in library_names:
             try:

--- a/espeak_phonemizer/__init__.py
+++ b/espeak_phonemizer/__init__.py
@@ -220,11 +220,17 @@ class Phonemizer:
             # Already initialized
             return
 
-        try:
-            self.lib_espeak = ctypes.cdll.LoadLibrary("libespeak-ng.so")
-        except OSError:
-            # Try .so.1
-            self.lib_espeak = ctypes.cdll.LoadLibrary("libespeak-ng.so.1")
+        library_names = ["libespeak-ng.so", "libespeak-ng.so.1", "libespeak-ng.dylib"]
+
+        for lib_name in library_names:
+            try:
+                self.lib_espeak = ctypes.cdll.LoadLibrary(lib_name)
+                break
+            except OSError:
+                continue
+        else:
+            raise OSError("Failed to load any of the specified libraries")
+
 
         sample_rate = self.lib_espeak.espeak_Initialize(
             Phonemizer.AUDIO_OUTPUT_SYNCHRONOUS, 0, None, 0
@@ -233,5 +239,10 @@ class Phonemizer:
 
         if self.stream_type == StreamType.MEMORY:
             # Initialize libc for memory stream
-            self.libc = ctypes.cdll.LoadLibrary("libc.so.6")
+            try:
+                self.libc = ctypes.cdll.LoadLibrary("libc.so.6")
+            except OSError:
+                # on Mac OS X, libc equiviliant is called libSystem
+                self.libc = ctypes.cdll.LoadLibrary("libc.dylib")
+                
             self.libc.open_memstream.restype = ctypes.POINTER(ctypes.c_char)


### PR DESCRIPTION
Added Mac OS library equivalents during applicable `ctypes.cdll.LoadLibrary(...)` calls.  

This fixes errors:
```
OSError: dlopen(libc.so.6, 0x0006): tried: 'libc.so.6' (no such file), ...
```
and
```
OSError: dlopen(libespeak-ng.so.1, 0x0006): tried: 'libespeak-ng.so.1' (no such file), ...
```
on Mac OS X (M1 - Ventura 13.4 (22F66))